### PR TITLE
Download SHA256 file instead of hardcoding

### DIFF
--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -19,7 +19,7 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=7.1.1.0
+PackageVersion=7.1.1.1
 DisplayVersion=7.1.1-beta5-uroesch
 
 [Dependencies]

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,9 +1,9 @@
 [Version]
-Package = 7.1.1.1
-Display = 7.1.1-beta5-uroesch
+Package = 7.1.1.2
+Display = 7.1.1-beta6-uroesch
 
 [Archive]
 URL1         = https://dbeaver.io/files/7.1.1/dbeaver-ce-7.1.1-win32.win32.x86_64.zip
-Checksum1    = SHA256:b0b0758755681bbaab7adcf5eea0ab24e3caa69c320d062f1f2c265b5e39fd26
+Checksum1    = SHA256::https://dbeaver.io/files/7.1.1/checksum/dbeaver-ce-7.1.1-win32.win32.x86_64.zip.sha256
 TargetName1  = DBeaver
 ExtractName1 = dbeaver


### PR DESCRIPTION
Summary:
  * Change Checksum format to either hold the
    checksum or a URL for downloading it.